### PR TITLE
Update to the new taxonomy

### DIFF
--- a/SqlDataCatalog-SqlDataMasker/DataMaskerHelpers.psm1
+++ b/SqlDataCatalog-SqlDataMasker/DataMaskerHelpers.psm1
@@ -208,18 +208,14 @@ function Get-MaskingTaxonomyTags {
         "City",
         "State",
         "ZIP Code",
+        "Full Address",
         "County",
         "Country",
         "Bank Account Number",
         "Debit/Credit Card Number",
         "Debit/Credit Card Expiry Date",
         "Social Security Number",
-        "URL",
-        "Bank Sort Code",
-        "SWIFT-BIC",
-        "Vehicle Registration Number",
-        "MAC Address",
-        "IP Address"
+        "URL"
     )
 }
 

--- a/SqlDataCatalog-SqlDataMasker/DataMaskerHelpers.psm1
+++ b/SqlDataCatalog-SqlDataMasker/DataMaskerHelpers.psm1
@@ -189,19 +189,37 @@ function Invoke-MaskDatabase {
 
 function Get-MaskingTaxonomyTags {
     return @(
-        "FirstName",
-        "Surname",
-        "FullName",
-        "DateOfBirth",
-        "EmailAddress",
-        "StreetAddress",
+        "Title",
+        "Given Name",
+        "Family Name",
+        "Full Name",
+        "Date Of Birth",
+        "Gender",
+        "Nationality",
+        "Occupation",
+        "Organization Name",
+        "Password",
+        "Passport Number",
+        "Driving License Number",
+        "Photo",
+        "Email Address",
+        "Phone Number",
+        "Street Address",
         "City",
         "State",
-        "PostalCode",
+        "ZIP Code",
         "County",
-        "CardNumber",
-        "BankSortCode",
-        "PhoneNumber"
+        "Country",
+        "Bank Account Number",
+        "Debit/Credit Card Number",
+        "Debit/Credit Card Expiry Date",
+        "Social Security Number",
+        "URL",
+        "Bank Sort Code",
+        "SWIFT-BIC",
+        "Vehicle Registration Number",
+        "MAC Address",
+        "IP Address"
     )
 }
 


### PR DESCRIPTION
Add in the new taxonomy to the samples repo. 

This gives the users a 1:1 mapping for the basic agreed initial taxonomy to a column template. 

We hope that in time this becomes a pointless part of the script as the default taxonomy work in Data Catalog will mean that these will be built into the information type