### PR TITLE
Update AdventureWorks Person.EmailAddress column

### DIFF
--- a/SqlDataCatalog-SqlDataMasker/Tag a column for masking.ps1
+++ b/SqlDataCatalog-SqlDataMasker/Tag a column for masking.ps1
@@ -15,7 +15,7 @@ $databaseName = 'AdventureWorks'
 
 $allColumns = Get-ClassificationColumn -instanceName $instanceName -databaseName $databaseName
 $emailColumn = $allColumns |
-    Where-Object { $_.ColumnName -like "Email address" -and $_.SchemaName -like "Person" }
+    Where-Object { $_.ColumnName -like "EmailAddress" -and $_.SchemaName -like "Person" }
 $emailColumn | Add-ClassificationColumnTag -category "Information Type" -tags @("Email address")
 $emailColumn | Add-ClassificationColumnTag -category "Information Classification" -tags @("Confidential")
 $emailColumn | Add-ClassificationColumnTag -category "Treatment Intent" -tags @("Static Masking")


### PR DESCRIPTION
We had accidentally started looking for a column in AdventureWorks matching our new taxonomy, which is an obvious mistake - their column names haven't changed!