### PR TITLE
Set log folder in TDM script

### DIFF
--- a/TDM/DataGeneration/run-data-generation.ps1
+++ b/TDM/DataGeneration/run-data-generation.ps1
@@ -65,5 +65,5 @@ if ($plan) {
 if ($populate) {
     Write-Output ""
     Write-Output "POPULATE: generating data into database"
-    .\rggenerate populate --target-connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs"--agree-to-eula
+    .\rggenerate populate --target-connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs" --agree-to-eula
 }

--- a/TDM/DataGeneration/run-data-generation.ps1
+++ b/TDM/DataGeneration/run-data-generation.ps1
@@ -59,11 +59,11 @@ if ($plan) {
     Write-Output ""
     Write-Output "PLAN: creating a generation.json file in $output"
     # .\rggenerate plan --connection-string "$connection_SqlAlchemy" --classification-file "$output\classification.json" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
-    .\rggenerate plan --connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
+    .\rggenerate plan --connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs"--agree-to-eula
 }
 
 if ($populate) {
     Write-Output ""
     Write-Output "POPULATE: generating data into database"
-    .\rggenerate populate --target-connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
+    .\rggenerate populate --target-connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs"--agree-to-eula
 }

--- a/TDM/DataGeneration/run-data-generation.ps1
+++ b/TDM/DataGeneration/run-data-generation.ps1
@@ -59,7 +59,7 @@ if ($plan) {
     Write-Output ""
     Write-Output "PLAN: creating a generation.json file in $output"
     # .\rggenerate plan --connection-string "$connection_SqlAlchemy" --classification-file "$output\classification.json" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
-    .\rggenerate plan --connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs"--agree-to-eula
+    .\rggenerate plan --connection-string "$connection_SqlAlchemy" --generation-file "$output\generation.json" --options-file "rggenerate-options.json" --log-folder "$output\logs" --agree-to-eula
 }
 
 if ($populate) {


### PR DESCRIPTION
This pull request includes changes to the `TDM/DataGeneration/run-data-generation.ps1` script . 

Logging enhancements:

* Added the `--log-folder` parameter to the `rggenerate plan` command and to the `rggenerate populate` command to specify a directory for log files. 

Closes https://github.com/red-gate/data-generation/issues/1287