### PR TITLE
Run Plan on target

### DIFF
--- a/TDM/DataGeneration/run-data-generation.ps1
+++ b/TDM/DataGeneration/run-data-generation.ps1
@@ -96,8 +96,8 @@ if ($classify) {
 if ($plan) {
     Write-Output ""
     Write-Output "PLAN: creating a generation.json file in $currentFolder"
-    # .\rggenerate plan --connection-string "$sourceConnection_SqlAlchemy" --classification-file "$currentFolder\classification.json" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
-    .\rggenerate plan --connection-string "$sourceConnection_SqlAlchemy" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --log-folder "$currentFolder\logs" --agree-to-eula
+    # .\rggenerate plan --connection-string "$targetConnection_SqlAlchemy" --classification-file "$currentFolder\classification.json" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
+    .\rggenerate plan --connection-string "$targetConnection_SqlAlchemy" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --log-folder "$currentFolder\logs" --agree-to-eula
 }
 
 if ($populate) {


### PR DESCRIPTION
Closes https://github.com/red-gate/data-generation/issues/1405

Tested it locally.

_Copilot generated summary_
This pull request includes a small but important change to the `TDM/DataGeneration/run-data-generation.ps1` script. The change updates the `connection-string` parameter in the `rggenerate plan` command.

* Updated the `connection-string` parameter to use `$targetConnection_SqlAlchemy` instead of `$sourceConnection_SqlAlchemy` in the `rggenerate plan` command.
