### PR TITLE
Add requirements linked to public doc

### DIFF
--- a/TDM/DataGeneration/readme.md
+++ b/TDM/DataGeneration/readme.md
@@ -1,25 +1,39 @@
+# Data Generation sample Instructions
+
+- [Data Generation sample Instructions](#data-generation-sample-instructions)
+  - [Requirements](#requirements)
+  - [Instructions](#instructions)
+  - [Troubleshooting](#troubleshooting)
+
+## Requirements
+
+Before you start:
+
+- Test Environment: Use a dedicated test environment to keep live data safe similar to the proof of concept environment below.
+- System Requirements: Make sure your system meets our minimum requirements [here](https://documentation.red-gate.com/x/-A4wE) for a smooth setup. 
+
 ## Instructions
+
 1. Download the script file [.\run-data-generation.ps1](run-data-generation.ps1) and the options file [./rggenerate-options.json](rggenerate-options.json).
-1. Download the [rggenerate executable](https://download.red-gate.com/EAP/RGGenerateWin64.zip) and extract it from the ZIP file, into the same directory as the script file and options file.
-1. Check whether you have the Microsoft Sql Server ODBC drivers installed.
-   - In the Start menu, open "ODBC Data Sources (64-bit)"
-   - Click the drivers tab
-   - Check for an entry "ODBC Driver 18 for Sql Server"
-1. If you do not have the Sql Server ODBC drivers installed, please [download them](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16) and install them. You may also need to install the [Microsoft C++ runtimes](https://aka.ms/vs/15/release/vc_redist.x64.exe). If you have a different version of the ODBC drivers installed, you may also need to edit the ODBC driver name.
-1. Edit the file [.\run-data-generation.ps1](run-data-generation.ps1). You need to enter your Sql Server instance details at the top in the `param` section.
-1. Run the script to plan data generation for your database by executing this command in the Windows command prompt. You may like to check the output generation json file afterwards.
-   ```
+2. Download the [rggenerate executable](https://download.red-gate.com/EAP/RGGenerateWin64.zip) and extract it from the ZIP file, into the same directory as the script file and options file.
+3. Edit the file [.\run-data-generation.ps1](run-data-generation.ps1). You need to enter your Sql Server instance details at the top in the `param` section.
+4. Run the script to plan data generation for your database by executing this command in the Windows command prompt. You may like to check the output generation json file afterwards.
+
+   ```PowerShell
    powershell -ep bypass .\run-data-generation.ps1 -plan
    ```
-1. Run the script to generate data and populate your database by executing this command
-   ```
+
+5. Run the script to generate data and populate your database by executing this command
+
+   ```PowerShell
    powershell -ep bypass .\run-data-generation.ps1 -populate
    ```
 
 ## Troubleshooting
+
 - You may need to set the [PowerShell Execution Policy](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.4) to ByPass, or Unrestricted.
 
-```
+```PowerShell
 # To determine your execution policy:
 Get-ExecutionPolicy
 


### PR DESCRIPTION
This pull request includes updates to the `TDM/DataGeneration/readme.md` file to improve the clarity and structure of the data generation instructions by 

- Adding a requirements section linked to the public document. 
- Updating the numbered lists based on this [GitHub doc](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#lists) as my Markdown tool suggested.