### PR TITLE
Rename rows count parameter in rggenerate

### DIFF
--- a/TDM/DataGeneration/rggenerate-options.json
+++ b/TDM/DataGeneration/rggenerate-options.json
@@ -1,6 +1,6 @@
 {
   "global": {
-    "defaultNumberOfRows": 10,
+    "rowsDefault": 10,
     "seed": 42
   }
 }


### PR DESCRIPTION
Renames deprecated defaultNumberOfRows to rowsDefault.

Official documentation has been [updated] (https://documentation.red-gate.com/display/rggen/Row+Count+Configuration) too.