### PR TITLE
Update connection string

### DIFF
--- a/TDM/DataGeneration/run-data-generation.ps1
+++ b/TDM/DataGeneration/run-data-generation.ps1
@@ -96,8 +96,7 @@ if ($classify) {
 if ($plan) {
     Write-Output ""
     Write-Output "PLAN: creating a generation.json file in $currentFolder"
-    # .\rggenerate plan --connection-string "$targetConnection_SqlAlchemy" --classification-file "$currentFolder\classification.json" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --agree-to-eula
-    .\rggenerate plan --connection-string "$targetConnection_SqlAlchemy" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --log-folder "$currentFolder\logs" --agree-to-eula
+    .\rggenerate plan --target-connection-string "$targetConnection_SqlAlchemy" --generation-file "$currentFolder\generation.json" --options-file "rggenerate-options.json" --log-folder "$currentFolder\logs" --agree-to-eula
 }
 
 if ($populate) {


### PR DESCRIPTION
This pull request includes a change to the `TDM/DataGeneration/run-data-generation.ps1` script to update the command-line arguments for the `rggenerate` tool. The most important change is the modification of the argument name for the connection string.

Command-line argument update:

* [`TDM/DataGeneration/run-data-generation.ps1`](diffhunk://#diff-67dad3b44b4636a321ddb4b031651194d973364869ed53543a2e7a394dad4415L99-R99): Changed the `--connection-string` argument to `--target-connection-string` in the `rggenerate plan` command.
